### PR TITLE
Fix: use "line_from" and "line_to" correctly

### DIFF
--- a/bin/checkee.js
+++ b/bin/checkee.js
@@ -94,7 +94,8 @@ function getComments({checkstyle, changedChunks}) {
 			if (line) {
 				comments.push({
 					fileName: line.fileName, 
-					line: error.line,
+					newLine: line.newLine,
+					previousLine: line.previousLine,
 					changed: line.changed,
 					message: `${error.message} ${messageIdentifier}`,
 					column: error.column,

--- a/bin/checkee.js
+++ b/bin/checkee.js
@@ -95,6 +95,7 @@ function getComments({checkstyle, changedChunks}) {
 				comments.push({
 					fileName: line.fileName, 
 					line: error.line,
+					changed: line.changed,
 					message: `${error.message} ${messageIdentifier}`,
 					column: error.column,
 				});

--- a/lib/bitbucket/backend.js
+++ b/lib/bitbucket/backend.js
@@ -65,8 +65,8 @@ module.exports = class BitbucketBackend {
 			formData,
 			url,
 			auth: {
-				username: this._username,
-				password: this._password,
+				user: this._username,
+				pass: this._password,
 			},
 		};
 	}

--- a/lib/bitbucket/pull-request.js
+++ b/lib/bitbucket/pull-request.js
@@ -74,11 +74,13 @@ module.exports = class BitbucketPullRequest {
 		// Line from is for unchanged and line to for changed
 		// see: https://bitbucket.org/site/master/issues/13110/post-comment-on-a-commit-pull-request-api
 		const lineParamKey = comment.changed ? 'line_to' : 'line_from';
+		const line = comment.changed ? comment.newLine : comment.previousLine;
 		
 		// From https://answers.atlassian.com/questions/32977327/are-you-planning-on-offering-an-update-pull-request-comment-api
 		// You can create inline comments with 1.0. Use the filename and line_from / line_to elements in the JSON request body, as per 
+		
 		return this._backend.request('post', url, {
-			[lineParamKey]: comment.line,
+			[lineParamKey]: line,
 			filename: comment.fileName,
 			content: comment.message,
 		}).then(({statusCode, body}) => {

--- a/lib/bitbucket/pull-request.js
+++ b/lib/bitbucket/pull-request.js
@@ -71,10 +71,14 @@ module.exports = class BitbucketPullRequest {
 	addComment(comment) {		
 		const url = `${constants.API_1_BASE}/repositories/${this.repository.repoUser}/${this.repository.repoSlug}/pullrequests/${this.pullRequestId}/comments`;
 		
+		// Line from is for unchanged and line to for changed
+		// see: https://bitbucket.org/site/master/issues/13110/post-comment-on-a-commit-pull-request-api
+		const lineParamKey = comment.changed ? 'line_to' : 'line_from';
+		
 		// From https://answers.atlassian.com/questions/32977327/are-you-planning-on-offering-an-update-pull-request-comment-api
 		// You can create inline comments with 1.0. Use the filename and line_from / line_to elements in the JSON request body, as per 
 		return this._backend.request('post', url, {
-			line_to: comment.line, // or line_to
+			[lineParamKey]: comment.line,
 			filename: comment.fileName,
 			content: comment.message,
 		}).then(({statusCode, body}) => {

--- a/lib/bitbucket/pull-request.spec.js
+++ b/lib/bitbucket/pull-request.spec.js
@@ -35,7 +35,7 @@ describe('GIVEN a pull request', () => {
 		it('THEN the backend talks to bitbucket API with line_from', () => {
 			pullRequest.addComment({
 				changed: false,
-				line: 100,
+				previousLine: 100,
 				fileName: 'package.json',
 				message: 'Test message',
 			});
@@ -60,7 +60,7 @@ describe('GIVEN a pull request', () => {
 		it('THEN the backend talks to bitbucket API with line_to', () => {
 			pullRequest.addComment({
 				changed: true,
-				line: 101,
+				newLine: 101,
 				fileName: 'package.json',
 				message: 'Test message',
 			});

--- a/lib/bitbucket/pull-request.spec.js
+++ b/lib/bitbucket/pull-request.spec.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const sinon = require('sinon');
+const chai = require('chai');
+
+const BitbucketBackend = require('./backend');
+const BitbucketRepository = require('./repository');
+
+const constants = require('./constants');
+const request = require('request');
+
+describe('GIVEN a pull request', () => {
+	var pullRequest;
+	
+	beforeEach(() => {
+		const backend = new BitbucketBackend({
+			username: 'my-username',
+			password: 'my-password',
+		});
+		
+		sinon.spy(request, 'post');
+		
+		pullRequest = new BitbucketRepository({
+			repoSlug: 'my-repo',
+			repoUser: 'my-repo-user',
+			backend: backend,
+		}).pullRequest(1011);
+	});
+	
+	afterEach(() => {
+		request.post.restore();
+	});
+	
+	describe('WHEN calling addComment with unchanged', () => {		
+		it('THEN the backend talks to bitbucket API with line_from', () => {
+			pullRequest.addComment({
+				changed: false,
+				line: 100,
+				fileName: 'package.json',
+				message: 'Test message',
+			});
+			chai.assert(request.post.calledOnce);
+			
+			const expectedUrl = `${constants.API_1_BASE}/repositories/my-repo-user/my-repo/pullrequests/1011/comments`;
+			const [{formData, url, auth}] = request.post.getCall(0).args;
+			chai.expect(url).to.equal(expectedUrl);
+			chai.expect(formData).to.deep.equal({
+				line_from: 100,
+				filename: 'package.json',
+				content: 'Test message',
+			});
+			chai.expect(auth).to.deep.equal({
+				user: 'my-username',
+				pass: 'my-password',
+			});
+		});
+	});
+	
+	describe('WHEN calling addComment with changed', () => {		
+		it('THEN the backend talks to bitbucket API with line_to', () => {
+			pullRequest.addComment({
+				changed: true,
+				line: 101,
+				fileName: 'package.json',
+				message: 'Test message',
+			});
+			chai.assert(request.post.calledOnce);
+			
+			const expectedUrl = `${constants.API_1_BASE}/repositories/my-repo-user/my-repo/pullrequests/1011/comments`;
+			const [{formData, url, auth}] = request.post.getCall(0).args;
+			chai.expect(url).to.equal(expectedUrl);
+			chai.expect(formData).to.deep.equal({
+				line_to: 101,
+				filename: 'package.json',
+				content: 'Test message',
+			});
+			chai.expect(auth).to.deep.equal({
+				user: 'my-username',
+				pass: 'my-password',
+			});
+		});
+	});
+});
+

--- a/lib/git/changed-chunks.js
+++ b/lib/git/changed-chunks.js
@@ -5,10 +5,15 @@ module.exports = class ChangedChunks {
 		var files = require('parse-diff')(diff) || {};
 		const changedChunks = files.map((file) => {
 			const fileName = file.to;
-			const chunks = file.chunks.map(makeLineChangedMap) || [];
+			
+			// group all chunks into one map of new line to previous and changed flag
+			// we want to end up with something like { 10: { changed: true}, 15 : { etc }}
+			const lines = file.chunks.map(makeLineChangedMap)
+			                         .reduce(reduceChunksIntoOne, {});
+			
 			return {
 				fileName,
-				chunks,
+				lines,
 			};
 		});
 		
@@ -21,12 +26,12 @@ module.exports = class ChangedChunks {
 			return null;
 		}
 		
-		const chunk = file.chunks.find((fileChunk) => {
-			return fileChunk[line] !== undefined;
-		});
-		if (chunk !== undefined) {
+		const lineDetails = file.lines[line];
+		if (lineDetails) {
 			return {
-				changed: chunk[line],
+				changed: lineDetails.changed,
+				previousLine: lineDetails.previousLine,
+				newLine: line,
 				fileName: file.fileName,
 			};
 		}
@@ -52,13 +57,24 @@ function compareFileNames(fileNameA, fileNameB) {
 }
 
 function makeLineChangedMap({changes}) {
-	return changes.reduce(function (accumulator, change) {
-		/**
-		 * We don't care for deleted lines as our changed chunk is purely
-		 * from the perception of the latest set, not what was there
-		 */
-		if (change.del) { return accumulator; }
-		accumulator[change.ln2 || change.ln] = !!change.add;
+	return changes.filter((change) => {
+		// we don't care for deletes when considering styles, only new lines
+		// or old lines that are still hanging about.
+		return !change.del;
+	}).reduce((accumulator, change) => {
+		// ln2 is new line after changes
+		const currentLine = change.ln || change.ln2;
+		accumulator[currentLine] = {
+			// ln1 represents previous line, otherwise ln is actual line
+			previousLine: change.ln || change.ln1,
+			// normal lines are not add or del
+			changed: !change.normal,
+		};
 		return accumulator;
 	}, {});
+}
+
+function reduceChunksIntoOne(accumulator, chunk) {
+	Object.assign(accumulator, chunk);
+	return accumulator;
 }

--- a/lib/git/changed-chunks.js
+++ b/lib/git/changed-chunks.js
@@ -5,7 +5,7 @@ module.exports = class ChangedChunks {
 		var files = require('parse-diff')(diff) || {};
 		const changedChunks = files.map((file) => {
 			const fileName = file.to;
-			const chunks = file.chunks.map(makeAddition) || [];
+			const chunks = file.chunks.map(makeLineChangedMap) || [];
 			return {
 				fileName,
 				chunks,
@@ -22,11 +22,11 @@ module.exports = class ChangedChunks {
 		}
 		
 		const chunk = file.chunks.find((fileChunk) => {
-			return fileChunk.startLine <= line && line <= fileChunk.endLine;
+			return fileChunk[line] !== undefined;
 		});
-		if (chunk) {
+		if (chunk !== undefined) {
 			return {
-				chunk,
+				changed: chunk[line],
 				fileName: file.fileName,
 			};
 		}
@@ -46,14 +46,19 @@ function compareFileNames(fileNameA, fileNameB) {
 	
 	const minLength = Math.min(filePartsA.length, filePartsB.length);
 	filePartsA.splice(minLength, filePartsA.length);
-	filePartsB.splice(minLength, filePartsA.length);
+	filePartsB.splice(minLength, filePartsB.length);
 	
 	return filePartsA.join('/') === filePartsB.join('/');
 }
 
-function makeAddition({newStart, newLines}) {
-	return {
-		startLine: newStart,
-		endLine: newStart + newLines,
-	};
+function makeLineChangedMap({changes}) {
+	return changes.reduce(function (accumulator, change) {
+		/**
+		 * We don't care for deleted lines as our changed chunk is purely
+		 * from the perception of the latest set, not what was there
+		 */
+		if (change.del) { return accumulator; }
+		accumulator[change.ln2 || change.ln] = !!change.add;
+		return accumulator;
+	}, {});
 }

--- a/lib/git/changed-chunks.spec.js
+++ b/lib/git/changed-chunks.spec.js
@@ -30,11 +30,48 @@ index a01fff5..c6020e4 100644
 	`;
 	const changedChunks = new ChangedChunks({diff});
 	
-	it('WHEN calling getLine with filename not changed', () => {
+	describe('WHEN calling getLine with filename not changed', () => {
 		it('THEN returns null', () => {
 			const got = changedChunks.getLine('not-package.json', 100);
 			const expected = null;
-			chai.expect(got).to.be(expected);
+			chai.expect(got).to.equal(expected);
+		});
+	});
+	
+	describe('WHEN calling getLine with added line', () => {
+		it('THEN returns line type ADDED', () => {
+			// +  "license": "MIT",
+			const got = changedChunks.getLine('package.json', 13).changed;
+			const expected = true;
+			chai.expect(got).to.equal(expected);
+		});
+	});
+	
+	describe('WHEN calling getLine with changed line', () => {
+		it('THEN returns line type CHANGED', () => {
+			// -    "dependency-1": "1.0.0",
+			// +    "dependency-1": "1.0.1",
+			const got = changedChunks.getLine('package.json', 20).changed;
+			const expected = true;
+			chai.expect(got).to.equal(expected);
+		});
+	});
+	
+	describe('WHEN calling getLine with unchanged line', () => {
+		it('THEN returns line type UNCHANGED', () => {
+			// "postinstall": "do something",
+			const got = changedChunks.getLine('package.json', 10).changed;
+			const expected = false;
+			chai.expect(got).to.equal(expected);
+		});
+	});
+	
+	describe('WHEN calling getLine with changed file relative to file system', () => {
+		it('THEN returns guesses filename', () => {
+			// "postinstall": "do something", (line 10)
+			const got = changedChunks.getLine('/Home/user/repo/package.json', 10).fileName;
+			const expected = 'package.json';
+			chai.expect(got).to.equal(expected);
 		});
 	});
 });

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "mocha": "3.2.0",
     "mocha-lcov-reporter": "1.2.0",
     "nock": "9.0.6",
-    "nyc": "10.1.2"
+    "nyc": "10.1.2",
+    "sinon": "2.0.0"
   },
   "dependencies": {
     "commander": "2.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -484,6 +484,10 @@ diff@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
 
+diff@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
+
 doctrine@^1.2.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
@@ -773,6 +777,12 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
+
+formatio@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
+  dependencies:
+    samsam "1.x"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -1086,6 +1096,10 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -1326,6 +1340,10 @@ log-driver@1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
 
+lolex@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -1434,6 +1452,10 @@ ms@0.7.1:
 mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
+
+native-promise-only@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -1596,6 +1618,12 @@ path-is-inside@^1.0.1:
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -1819,6 +1847,10 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
+samsam@1.x, samsam@^1.1.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
+
 sax@>=0.6.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
@@ -1846,6 +1878,19 @@ signal-exit@^2.0.0:
 signal-exit@^3.0.0, signal-exit@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+sinon@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-2.0.0.tgz#48337fa489069e530ad7e2f44f07b0ae93d37b24"
+  dependencies:
+    diff "^3.1.0"
+    formatio "1.2.0"
+    lolex "^1.6.0"
+    native-promise-only "^0.8.1"
+    path-to-regexp "^1.7.0"
+    samsam "^1.1.3"
+    text-encoding "0.6.4"
+    type-detect "^4.0.0"
 
 slice-ansi@0.0.4:
   version "0.0.4"
@@ -1995,6 +2040,10 @@ test-exclude@^3.3.0:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
+text-encoding@0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -2038,6 +2087,10 @@ type-detect@0.1.1:
 type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
+
+type-detect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.0.tgz#62053883542a321f2f7b25746dc696478b18ff6b"
 
 typedarray@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
To work with the current expectations of bitbuckets create comment endpoint

- If line is deleted we will ignore the line,
- If line is changed (i.e, added) we'll pass in the new line as "line_to",
- If line is unchanged we'll pass in the previous line as "line_from"

This should resolve #2

Reference: https://bitbucket.org/site/master/issues/13110/post-comment-on-a-commit-pull-request-api
